### PR TITLE
swap out rabbitmq component for default redis

### DIFF
--- a/pub_sub/components/pubsub.yaml
+++ b/pub_sub/components/pubsub.yaml
@@ -3,21 +3,13 @@ kind: Component
 metadata:
   name: order_pub_sub
 spec:
-  type: pubsub.rabbitmq
+  type: pubsub.redis
   version: v1
   metadata:
-  - name: host
-    value: "amqp://localhost:5672"
-  - name: durable
-    value: "false"
-  - name: deletedWhenUnused
-    value: "false"
-  - name: autoAck
-    value: "false"
-  - name: reconnectWait
-    value: "0"
-  - name: concurrency
-    value: parallel
+  - name: redisHost
+    value: localhost:6379
+  - name: redisPassword
+    value: ""
 scopes:
   - orderprocessing
   - checkout


### PR DESCRIPTION
- yaml file is changed to make the pubsub examples use redis instead of rabbitMQ.

Issue #3 